### PR TITLE
fix: pg in query

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -17,6 +17,9 @@ use tracing::{info_span, Span};
 use tracing_futures::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+pub const QUERY_KEY: &str = "query";
+pub const PARAMETERS_KEY: &str = "parameters";
+
 #[async_trait]
 impl<Q: Queryable + ?Sized> QueryExt for Q {
     async fn filter(
@@ -88,8 +91,8 @@ impl<Q: Queryable + ?Sized> QueryExt for Q {
         _features: psl::PreviewFeatures,
     ) -> std::result::Result<usize, crate::error::RawError> {
         // Unwrapping query & params is safe since it's already passed the query parsing stage
-        let query = inputs.remove("query").unwrap().into_string().unwrap();
-        let params = inputs.remove("parameters").unwrap().into_list().unwrap();
+        let query = inputs.remove(QUERY_KEY).unwrap().into_string().unwrap();
+        let params = inputs.remove(PARAMETERS_KEY).unwrap().into_list().unwrap();
         let params = params.into_iter().map(convert_lossy).collect_vec();
         let changes = AssertUnwindSafe(self.execute_raw_typed(&query, &params))
             .catch_unwind()

--- a/query-engine/query-engine/src/server/a.prisma
+++ b/query-engine/query-engine/src/server/a.prisma
@@ -3,8 +3,6 @@ datasource db {
   url      = "postgres://*@localhost:5433/zjl"
 }
 
-model cities {
-  name     String?   @db.VarChar(80)
-  location Geometry? @db.Geography(Point, 4326)
-  id       Int       @id(map: "cities_pk")
+model k {
+  id Int @id
 }

--- a/schema-engine/core/src/lib.rs
+++ b/schema-engine/core/src/lib.rs
@@ -380,7 +380,7 @@ model User {
         let intro_res = test_introspect(
             &r##"datasource db {
               provider = "postgres"
-                url      = "postgres://*@localhost:5433/zjl"
+              url      = "postgres://*@localhost:5433/zjl"
         
                }"##
             .to_string(),
@@ -397,14 +397,21 @@ model User {
         tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).init();
         let source = r##"
         datasource db {
-  provider = "mysql"
-  url      = "mysql://root:*@localhost:3306/geo"
+  provider = "postgres"
+  url      = "postgres:/*@localhost:5433/zjl"
 }
-
-model places {
-  id       Int       @id @default(autoincrement())
-  name     String?   @db.VarChar(255)
-  location Geometry? @db.Point
+model Account {
+    membershipEndTime DateTime?
+    createdAt DateTime @default(now())
+    updatedAt DateTime
+    deletedAt DateTime?
+    membershipId String? @db.Uuid
+    leftDuration Decimal @default(0) @db.Decimal(13, 3)
+    typeId String
+    id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+    type String @default("User")
+    
+    @@unique([type, typeId])
 }
         "##;
         let res = test_push(&source).await;


### PR DESCRIPTION
1. pg 数据库 in quey
```
prisma:
datasource db {
  provider = "postgres"
  url      = "postgres://*@localhost:5433/zjl"
}

model k {
  id Int @id
}

prisam query:
{
    "query": "mutation{queryRaw(query: \"select * from k where id in $1 and id = $2\", parameters: \"[[1,2],1]\")}",
    "variables": {

    }
}
```
2. mysql 数据库 in query
```
prisma:
datasource db {
  provider = "mysql"
  url      = "mysql://*@localhost:3306/zjl"
}

model k {
  id Int @id
}

prisma query:
{
    "query": "mutation{queryRaw(query: \"select * from k where id in ? and id = ?\", parameters: \"[[1,2,3],1]\")}",
    "variables": {}
}
```